### PR TITLE
Extract shipment order result carton info

### DIFF
--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -25,33 +25,6 @@ module Documents
       }
     end
 
-    private
-
-    def items_hash(child)
-      { line: child['Line'],
-        item_number: child['ItemNumber'],
-        quantity: child['Quantity'],
-        exception_code: child['ExceptionCode'],
-        tax: child['Tax'],
-        total: child['Total'],
-        substituted_item: child['substituted_item'] }
-    end
-
-    def create_carton_hash(child)
-      @carton = { carton_id: child['CartonId'],
-                  tracking_id: child['TrackingId'],
-                  carrier: child['Carrier'],
-                  carton_number: child['CartonNumber'],
-                  service_level: child['ServiceLevel'],
-                  weight: child['Weight'],
-                  freight_cost: @freight_cost,
-                  line_items: [] }
-
-      @carton[:line_items] << child.children.collect { |ch|
-        { line: ch['Line'],
-          item_number: ch['ItemNumber'],
-          quantity: ch['Quantity'] }}
-    end
   end
 end
 

--- a/lib/documents/shipment_order_result.rb
+++ b/lib/documents/shipment_order_result.rb
@@ -1,5 +1,31 @@
+#
+# A ShipmentOrderResult lists items shipped, tracking number, carrier
+# information, and packaging details.
+#
+# The structure of the XML document is:
+#
+=begin
+  <SOResult ...>
+    <Line ... />
+    <Line ... />
+    <Line ... />
+    <Carton ... >
+      <Content ... />
+      <Content ... />
+    </Carton>
+    <Carton ... >
+      <Content ... />
+    </Carton>
+    <Extension />
+  </SOResult>
+=end
+#
+# See the specs for a full example.
+
 module Documents
   class ShipmentOrderResult
+    NAMESPACE = 'http://schemas.quiettechnology.com/V2/SOResultDocument.xsd'
+
     attr_reader :type
 
     def initialize(xml)
@@ -17,12 +43,37 @@ module Documents
     def to_h
       {
         id: @shipment_number,
+        # NOTE: There may multiple tracking numbers. This is just the first.
         tracking: @tracking_number,
         warehouse: @warehouse,
         status: 'shipped',
         business_unit: @business_unit,
-        shipped_at: @date_shipped
+        shipped_at: @date_shipped,
+        cartons: cartons_to_h,
       }
+    end
+
+    private
+
+    def cartons_to_h
+      cartons = @doc.xpath('ql:SOResult/ql:Carton', 'ql' => NAMESPACE)
+      cartons.map do |carton|
+        {
+          :id => carton['CartonId'],
+          :tracking => carton['TrackingId'],
+          :line_items => carton_line_items_to_h(carton),
+        }
+      end
+    end
+
+    def carton_line_items_to_h(carton)
+      contents = carton.xpath('ql:Content', 'ql' => NAMESPACE)
+      contents.map do |content|
+        {
+          :ql_item_number => content['ItemNumber'],
+          :quantity => Integer(content['Quantity']),
+        }
+      end
     end
 
   end

--- a/spec/lib/documents/shipment_order_result_spec.rb
+++ b/spec/lib/documents/shipment_order_result_spec.rb
@@ -3,10 +3,89 @@ require 'spec_helper'
 module Documents
   describe ShipmentOrderResult do
 
-    xit 'should convert document to a shipment message' do
-      xml = xml('T123456')
-      message = ShipmentOrderResult.new(xml).to_message
-      message[:messages].first[:message].should eq 'ql:shipment:confirm'
+    it 'should convert a document to a hash' do
+      xml = <<-XML
+        <?xml version="1.0" encoding="utf-8"?>
+        <SOResult
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            ClientID="BONOBOS"
+            BusinessUnit="BONOBOS" OrderNumber="H13088556647"
+            DateShipped="2015-02-24T15:51:31.0953088Z"
+            FreightCost="0"
+            CartonCount="1"
+            Warehouse="DVN"
+            xmlns="http://schemas.quiettechnology.com/V2/SOResultDocument.xsd">
+          <Line Line="1" ItemNumber="1111111" Quantity="1" ExceptionCode="" Tax="0" Total="0" SubstitutedItem="" />
+          <Line Line="2" ItemNumber="2222222" Quantity="1" ExceptionCode="" Tax="0" Total="0" SubstitutedItem="" />
+          <Line Line="3" ItemNumber="3333333" Quantity="1" ExceptionCode="" Tax="0" Total="0" SubstitutedItem="" />
+          <Carton
+              CartonId="S11111111"
+              TrackingId="1Z1111111111111111"
+              Carrier="UPS"
+              CartonNumber="1"
+              ServiceLevel="GROUND"
+              Weight="1.11"
+              FreightCost="11.11"
+              HandlingFee="0"
+              Surcharge="0"
+              PackageType="SINGLE">
+            <Content Line="1" ItemNumber="1111111" Quantity="1" />
+            <Content Line="2" ItemNumber="2222222" Quantity="1" />
+          </Carton>
+          <Carton
+              CartonId="S22222222"
+              TrackingId="1Z2222222222222222"
+              Carrier="UPS"
+              CartonNumber="1"
+              ServiceLevel="GROUND"
+              Weight="2.22"
+              FreightCost="22.22"
+              HandlingFee="0"
+              Surcharge="0"
+              PackageType="LARGE1">
+            <Content Line="3" ItemNumber="3333333" Quantity="1" />
+          </Carton>
+          <Extension />
+        </SOResult>
+      XML
+
+      result = ShipmentOrderResult.new(xml)
+
+      expect(result.to_h).to eq(
+        :id => "H13088556647",
+        :tracking => "1Z1111111111111111",
+        :warehouse => "DVN",
+        :status => "shipped",
+        :business_unit => "BONOBOS",
+        :shipped_at => "2015-02-24T15:51:31.0953088Z",
+        :cartons => [
+          {
+            :id => "S11111111",
+            :tracking => "1Z1111111111111111",
+            :line_items => [
+              {
+                :ql_item_number => "1111111",
+                :quantity => 1,
+              },
+              {
+                :ql_item_number => "2222222",
+                :quantity => 1,
+              },
+            ],
+          },
+          {
+            :id => "S22222222",
+            :tracking => "1Z2222222222222222",
+            :line_items => [
+              {
+                :ql_item_number => "3333333",
+                :quantity => 1,
+              },
+            ],
+          },
+        ],
+      )
     end
   end
 end


### PR DESCRIPTION
Extract carton info from ShipmentOrderResults

We need this in order to handle short ships and multiple tracking numbers, among
other things.

There more info we could extract, but we can add to this later if desired.

Also, remove some unused code in ShipmentOrderResult.