### PR TITLE
Fixes Shipment Order Payload

### DIFF
--- a/lib/documents/shipment_order.rb
+++ b/lib/documents/shipment_order.rb
@@ -68,13 +68,13 @@ module Documents
     def bill_to_hash
       {
         'Company'    => full_name,
-        'Contact'    => @shipment['shipping_address']['contact'],
-        'Address1'   => @shipment['shipping_address']['address1'],
-        'Address2'   => @shipment['shipping_address']['address2'],
-        'City'       => @shipment['shipping_address']['city'],
-        'State'      => @shipment['shipping_address']['state'],
-        'PostalCode' => @shipment['shipping_address']['zipcode'],
-        'Country'    => @shipment['shipping_address']['country']
+        'Contact'    => @shipment['billing_address']['contact'],
+        'Address1'   => @shipment['billing_address']['address1'],
+        'Address2'   => @shipment['billing_address']['address2'],
+        'City'       => @shipment['billing_address']['city'],
+        'State'      => @shipment['billing_address']['state'],
+        'PostalCode' => @shipment['billing_address']['zipcode'],
+        'Country'    => @shipment['billing_address']['country']
       }
     end
 


### PR DESCRIPTION
The `BillTo` node of a shipment-order should use the shipment's billing address, rather than incorrectly using the shipping address.